### PR TITLE
More compatibilty to older Laravel and PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "illuminate/database": "^10.13.2",
-        "illuminate/http": "^10.13.2",
-        "illuminate/routing": "^10.13.2",
-        "illuminate/support": "^10.13.2"
+        "php": "^7.2",
     },
     "require-dev": {
         "laravel/sail": "^1.9",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2"
     },
     "require-dev": {
         "laravel/sail": "^1.9",

--- a/src/SyncService.php
+++ b/src/SyncService.php
@@ -39,6 +39,7 @@ class SyncService
             }
         } else {
             $lastPulledAt = Carbon::createFromTimestampUTC($lastPulledAt);
+            $lastPulledAt->setTimezone(config('app.timezone'));
 
             foreach ($this->models as $name => $class) {
                 $changes[$name] = [

--- a/src/SyncService.php
+++ b/src/SyncService.php
@@ -12,7 +12,7 @@ use NathanHeffley\LaravelWatermelon\Exceptions\ConflictException;
 
 class SyncService
 {
-    protected array $models;
+    protected $models;
 
     public function __construct(array $models)
     {
@@ -96,7 +96,7 @@ class SyncService
                 try {
                     $model = $class::query()->where(config('watermelon.identifier'), $create->get(config('watermelon.identifier')))->firstOrFail();
                     $model->update($create->toArray());
-                } catch (ModelNotFoundException) {
+                } catch (ModelNotFoundException $e) {
                     $class::query()->create($create->toArray());
                 }
             });
@@ -133,16 +133,16 @@ class SyncService
                             ->watermelon()
                             ->firstOrFail();
                         $task->update($update->toArray());
-                    } catch (ModelNotFoundException) {
+                    } catch (ModelNotFoundException $e) {
                         try {
                             $class::query()->create($update->toArray());
-                        } catch (QueryException) {
+                        } catch (QueryException $e) {
                             throw new ConflictException;
                         }
                     }
                 });
             }
-        } catch (ConflictException) {
+        } catch (ConflictException $e) {
             DB::rollBack();
 
             return response()->json('', 409);


### PR DESCRIPTION
Hi, 

Here I'm working in Laravel 6.x and PHP 7.2 and I need do some modifies to improve compatibility. I think those changes wont break in php 8 or new versions, basically was typing changes.

Another change is why here I'm in GMT-3, my created_at, updated_at, deleted_at was saved in this timezone, in a datetime field on my database mysql. When the sync push changes they send the latest pull timestamp, who are in gmt-3, and this library whas changing this to GMT-0. It cause not pull my recent changes.

If this changes can break the project I can improve some modifies, jus let me know. 

Thank you for your work.